### PR TITLE
Change both buttons to blue when on Details page

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -87,6 +87,10 @@ function App() {
 
   const { pathname } = useLocation();
 
+  const clearClicked = () => {
+    setClicked('')
+  }
+
   return (
     <div className="App">
       {error && <Error closeError={closeError} />}
@@ -127,6 +131,7 @@ function App() {
               updateError={updateError}
               addComment={addComment}
               deleteComment={deleteComment}
+              clearClicked={clearClicked}
             />
           }
         />

--- a/src/components/Details/Details.tsx
+++ b/src/components/Details/Details.tsx
@@ -16,13 +16,15 @@ const Details = ({
   updateError,
   toggleFav,
   addComment,
-  deleteComment
+  deleteComment,
+  clearClicked
 }: {
   top100: CleanedGame[];
   updateError: () => void;
   toggleFav: (id: string) => void;
   addComment: (review: Review, id: string) => void;
   deleteComment: (commentId: number, id: string) => void;
+  clearClicked: () => void
 }) => {
   const [gameInfo, setGameInfo] = useState<CleanDetails>(Object);
   const [isLoading, setisLoading] = useState<boolean>(true);
@@ -33,6 +35,7 @@ const Details = ({
       .then((data) => {
         setGameInfo(cleanDetails(data, top100));
         setisLoading(false)
+        clearClicked()
       })
       .catch((response) => {
         console.log(response.status);


### PR DESCRIPTION
# Description
I noticed that one button would still be greyed out when on a game details page, depending on what page you came from. This branch fixes that so that when you go to a details page, it changes both buttons back to blue.

# Fixes # (issue)

# Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)
 
- [ ]  New feature (non-breaking change which adds functionality)

- [ ]  Breaking change (fix or feature that would cause existing functionality not to work as expected)

- [ ] This change requires a documentation update

-  [x] Styling

- [ ] Refactor

- [ ] Testing

# Where were the changes?


# Checklist:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my code
- [ ]  I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ]  I have made corresponding changes to the documentation (if applicable)
- [x]  My changes generate no new warnings

# Contributors (paired programming):
